### PR TITLE
Fixes `Containerfile` brain fart

### DIFF
--- a/src/container/Containerfile
+++ b/src/container/Containerfile
@@ -39,5 +39,5 @@ RUN mkdir /usr/local/share/ca-certificates/lets-encrypt && \
   update-ca-certificates
   
 # YQ, use the snap since it's directly supported
-snap install yq
+RUN snap install yq
 


### PR DESCRIPTION
TL;DR
-----

Repairs defect of missing `RUN` in `Containerfile`

Details
-------

Too fast on the PR on the last one, missed an error in the
`Containerfile` that left out a `RUN` when installing the `yq`
snap. This one fixes that one.
