### PR TITLE
Switches to GitHub release for downloading `yq`

### DIFF
--- a/src/container/Containerfile
+++ b/src/container/Containerfile
@@ -19,6 +19,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
   apt-get update && apt-get install -y packer \
     terraform \
     vault
+
 RUN apt-get clean
 
 # govc VMware command-line
@@ -38,6 +39,5 @@ RUN mkdir /usr/local/share/ca-certificates/lets-encrypt && \
   curl --output /usr/local/share/ca-certificates/lets-encrypt/lets-encrypt-e1.crt https://letsencrypt.org/certs/lets-encrypt-e1.pem && \
   update-ca-certificates
   
-# YQ, use the snap since it's directly supported
-RUN snap install yq
-
+# YQ, using the contributed package
+ADD https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 /usr/local/bin/yq


### PR DESCRIPTION
TL;DR
-----

Downloads `yq` from GitHub directly

Details
-------

After issues with both the snap and the Debian package I shifted
to a direct download from GitHub to install `yq` for the image.
This change uses that approach.
