### PR TITLE
Chore bump linux to jammy

### DIFF
--- a/src/container/Containerfile
+++ b/src/container/Containerfile
@@ -11,12 +11,12 @@ RUN apt-get update && apt-get install -y \
 
 # kubectl
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -&& \
-  echo "deb [arch=amd64] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+  echo "deb [arch=amd64] https://apt.kubernetes.io/ kubernetes-focal main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl 
 
 # hashicorp tooling
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-  echo "deb [arch=amd64] https://apt.releases.hashicorp.com xenial main" | tee /etc/apt/sources.list.d/hashicorp.list && \
+  echo "deb [arch=amd64] https://apt.releases.hashicorp.com focal main" | tee /etc/apt/sources.list.d/hashicorp.list && \
   apt-get update && apt-get install -y packer \
     terraform \
     vault

--- a/src/container/Containerfile
+++ b/src/container/Containerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal 
+FROM ubuntu:jammy 
 
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
@@ -40,7 +40,7 @@ RUN mkdir /usr/local/share/ca-certificates/lets-encrypt && \
   curl --output /usr/local/share/ca-certificates/lets-encrypt/lets-encrypt-e1.crt https://letsencrypt.org/certs/lets-encrypt-e1.pem && \
   update-ca-certificates
   
-# YQ, using the contributed package
+# YQ, using the github release
 RUN curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | \
   jq '.assets[] | select(.name == "yq_linux_amd64").browser_download_url' | \
   xargs curl --location --output /usr/local/bin/yq && \


### PR DESCRIPTION
TL;DR
-----

Changes base image to use Ubuntu Jammy Jellyfish (22.04 LTS)

Details
-------

Picks up an old branch that updated/fixes the base image from 
Xenial to the intended Focal. In the meantime, Jammy came out
so we go to Jammy.

* Updates the base image to Jammy
* Fixes a misleading comment in `Containerfile` about where the
  `yq` install comes from